### PR TITLE
E2e port management

### DIFF
--- a/internal/testutil/eth1_test.go
+++ b/internal/testutil/eth1_test.go
@@ -1,7 +1,6 @@
 package testutil
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -37,6 +36,7 @@ func TestEth1_Multiple(t *testing.T) {
 	srv2, err := NewEth1Server()
 	assert.NoError(t, err)
 
-	fmt.Println(srv1.node.GetAddr(NodePortEth1Http))
-	fmt.Println(srv2.node.GetAddr(NodePortEth1Http))
+	addr1 := srv1.node.GetAddr(NodePortEth1Http)
+	addr2 := srv2.node.GetAddr(NodePortEth1Http)
+	assert.NotEqual(t, addr1, addr2)
 }

--- a/internal/testutil/eth1_test.go
+++ b/internal/testutil/eth1_test.go
@@ -1,13 +1,14 @@
 package testutil
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/umbracle/ethgo"
 )
 
-func TestEth1(t *testing.T) {
+func TestEth1_Deposit(t *testing.T) {
 	eth1, err := NewEth1Server()
 	assert.NoError(t, err)
 
@@ -25,4 +26,17 @@ func TestEth1(t *testing.T) {
 	count, err := contract.GetDepositCount(ethgo.Latest)
 	assert.NoError(t, err)
 	assert.Equal(t, int(count[0]), 1)
+}
+
+func TestEth1_Multiple(t *testing.T) {
+	// test that multiple eth1 nodes are deployed and
+	// get assigned a different port
+	srv1, err := NewEth1Server()
+	assert.NoError(t, err)
+
+	srv2, err := NewEth1Server()
+	assert.NoError(t, err)
+
+	fmt.Println(srv1.node.GetAddr(NodePortEth1Http))
+	fmt.Println(srv2.node.GetAddr(NodePortEth1Http))
 }

--- a/internal/testutil/eth2_lighthouse.go
+++ b/internal/testutil/eth2_lighthouse.go
@@ -68,7 +68,7 @@ func NewLighthouseValidator(account *Account, spec *Eth2Spec, beacon Node) (*Lig
 		"lighthouse", "vc",
 		"--debug-level", "debug",
 		"--datadir", "/data/node",
-		"--beacon-nodes", beacon.GetAddr("eth2.http"),
+		"--beacon-nodes", beacon.GetAddr(NodePortHttp),
 		"--testnet-dir", "/data",
 		"--init-slashing-protection",
 	}

--- a/internal/testutil/eth2_lighthouse.go
+++ b/internal/testutil/eth2_lighthouse.go
@@ -2,7 +2,6 @@ package testutil
 
 import (
 	"encoding/hex"
-	"fmt"
 
 	"github.com/umbracle/eth2-validator/internal/beacon"
 	"github.com/umbracle/eth2-validator/internal/bls"
@@ -10,7 +9,7 @@ import (
 
 // LighthouseBeacon is a prysm test server
 type LighthouseBeacon struct {
-	node   *node
+	*node
 	config *beacon.ChainConfig
 }
 
@@ -23,7 +22,7 @@ func NewLighthouseBeacon(e *Eth1Server) (*LighthouseBeacon, error) {
 	cmd := []string{
 		"lighthouse", "beacon_node",
 		"--http", "--http-address", "0.0.0.0",
-		"--http-port", eth2ApiPort,
+		"--http-port", `{{ Port "eth2.http" }}`,
 		"--eth1-endpoints", e.http(),
 		"--testnet-dir", "/data",
 		"--http-allow-sync-stalled",
@@ -48,10 +47,6 @@ func NewLighthouseBeacon(e *Eth1Server) (*LighthouseBeacon, error) {
 	return srv, nil
 }
 
-func (b *LighthouseBeacon) IP() string {
-	return b.node.IP()
-}
-
 func (b *LighthouseBeacon) Type() NodeClient {
 	return Lighthouse
 }
@@ -73,7 +68,7 @@ func NewLighthouseValidator(account *Account, spec *Eth2Spec, beacon Node) (*Lig
 		"lighthouse", "vc",
 		"--debug-level", "debug",
 		"--datadir", "/data/node",
-		"--beacon-nodes", fmt.Sprintf("http://%s:%s", beacon.IP(), eth2ApiPort),
+		"--beacon-nodes", beacon.GetAddr("eth2.http"),
 		"--testnet-dir", "/data",
 		"--init-slashing-protection",
 	}

--- a/internal/testutil/eth2_lighthouse_test.go
+++ b/internal/testutil/eth2_lighthouse_test.go
@@ -1,7 +1,6 @@
 package testutil
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -28,7 +27,7 @@ func TestEth2_Lighthouse_SingleNode(t *testing.T) {
 
 	NewLighthouseValidator(account, spec, b)
 
-	api := beacon.NewHttpAPI(fmt.Sprintf("http://%s:5050", b.IP()))
+	api := beacon.NewHttpAPI(b.GetAddr(NodePortHttp))
 
 	require.Eventually(t, func() bool {
 		syncing, err := api.Syncing()

--- a/internal/testutil/eth2_prysm_test.go
+++ b/internal/testutil/eth2_prysm_test.go
@@ -1,7 +1,6 @@
 package testutil
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -28,7 +27,7 @@ func TestEth2_Prysm_SingleNode(t *testing.T) {
 
 	NewPrysmValidator(account, spec, b)
 
-	api := beacon.NewHttpAPI(fmt.Sprintf("http://%s:5050", b.IP()))
+	api := beacon.NewHttpAPI(b.GetAddr(NodePortHttp))
 
 	require.Eventually(t, func() bool {
 		syncing, err := api.Syncing()

--- a/internal/testutil/eth2_teku.go
+++ b/internal/testutil/eth2_teku.go
@@ -1,15 +1,13 @@
 package testutil
 
 import (
-	"fmt"
-
 	"github.com/umbracle/eth2-validator/internal/beacon"
 	"github.com/umbracle/eth2-validator/internal/bls"
 )
 
 // TekuBeacon is a teku test server
 type TekuBeacon struct {
-	node   *node
+	*node
 	config *beacon.ChainConfig
 }
 
@@ -31,7 +29,7 @@ func NewTekuBeacon(e *Eth1Server) (*TekuBeacon, error) {
 		// config
 		"--network", "/data/config.yaml",
 		// port
-		"--rest-api-port", eth2ApiPort,
+		"--rest-api-port", `{{ Port "eth2.http" }}`,
 		// debug log
 		"--logging", "debug",
 	}
@@ -52,10 +50,6 @@ func NewTekuBeacon(e *Eth1Server) (*TekuBeacon, error) {
 		config: testConfig.GetChainConfig(),
 	}
 	return srv, nil
-}
-
-func (b *TekuBeacon) IP() string {
-	return b.node.IP()
 }
 
 func (b *TekuBeacon) Stop() {
@@ -79,7 +73,7 @@ func NewTekuValidator(account *Account, spec *Eth2Spec, beacon Node) (*TekuValid
 	cmd := []string{
 		"vc",
 		// beacon api
-		"--beacon-node-api-endpoint", fmt.Sprintf("http://%s:%s", beacon.IP(), eth2ApiPort),
+		"--beacon-node-api-endpoint", beacon.GetAddr(NodePortHttp),
 		// data
 		"--data-path", "/data",
 		// eth1x deposit contract (required for custom networks)

--- a/internal/testutil/eth2_teku_test.go
+++ b/internal/testutil/eth2_teku_test.go
@@ -1,7 +1,6 @@
 package testutil
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -29,7 +28,7 @@ func TestEth2_Teku_SingleNode(t *testing.T) {
 
 	NewTekuValidator(account, spec, b)
 
-	api := beacon.NewHttpAPI(fmt.Sprintf("http://%s:5050", b.IP()))
+	api := beacon.NewHttpAPI(b.GetAddr(NodePortHttp))
 
 	assert.Eventually(t, func() bool {
 		syncing, err := api.Syncing()


### PR DESCRIPTION
Before, the `e2e` framework would assume the same port for all the types of nodes (i.e. beacon node HTTP port was 5050). This is not a problem since all the nodes would run on an independent container with an isolated network and IP. However, for #15 some nodes need to run on host in order to advertise their (address, port) to other nodes (which does not work on isolated containers). Thus, we needed a way to customize and avoid port clashing among the nodes.