### PR TITLE
Improve e2e framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+# 0.1.1 (Unreleased)
+
+- Use multiple accounts in e2e validators for Teky, Prysm and Lighthouse [[GH-25](https://github.com/umbracle/eth2-validator/issues/25)]
+
 # 0.1.0 (12 May, 2022)
 
 - Initial public release.

--- a/internal/cmd/e2e_deploy.go
+++ b/internal/cmd/e2e_deploy.go
@@ -44,7 +44,10 @@ func (c *E2EDeployCommand) Run(args []string) int {
 	}
 
 	c.UI.Output("=> Provision beacon node")
-	b, err := testutil.NewTekuBeacon(eth1)
+	bCfg := &testutil.BeaconConfig{
+		Eth1: eth1,
+	}
+	b, err := testutil.NewTekuBeacon(bCfg)
 	if err != nil {
 		c.UI.Error(err.Error())
 		return 1
@@ -59,7 +62,12 @@ func (c *E2EDeployCommand) Run(args []string) int {
 	c.UI.Output(hex.EncodeToString(key))
 
 	c.UI.Output("=> Provision validator")
-	v, err := testutil.NewTekuValidator(account, spec, b)
+	vCfg := &testutil.ValidatorConfig{
+		Accounts: []*testutil.Account{account},
+		Spec:     spec,
+		Beacon:   b,
+	}
+	v, err := testutil.NewTekuValidator(vCfg)
 	if err != nil {
 		c.UI.Error(err.Error())
 		return 1

--- a/internal/testutil/eth1.go
+++ b/internal/testutil/eth1.go
@@ -6,38 +6,11 @@ import (
 	"time"
 
 	"github.com/umbracle/eth2-validator/internal/beacon"
-	"github.com/umbracle/eth2-validator/internal/bls"
 	"github.com/umbracle/eth2-validator/internal/deposit"
 	"github.com/umbracle/ethgo"
 	"github.com/umbracle/ethgo/contract"
 	"github.com/umbracle/ethgo/jsonrpc"
-	"github.com/umbracle/ethgo/wallet"
 )
-
-type NodeClient string
-
-const (
-	Teku       NodeClient = "teku"
-	Prysm      NodeClient = "prysm"
-	Lighthouse NodeClient = "lighthouse"
-)
-
-type Account struct {
-	Bls   *bls.Key
-	Ecdsa *wallet.Key
-}
-
-func NewAccount() *Account {
-	key, err := wallet.GenerateKey()
-	if err != nil {
-		panic(fmt.Errorf("BUG: failed to generate key %v", err))
-	}
-	account := &Account{
-		Bls:   bls.NewRandomKey(),
-		Ecdsa: key,
-	}
-	return account
-}
 
 // Eth1Server is an eth1x testutil server using go-ethereum
 type Eth1Server struct {
@@ -222,10 +195,4 @@ func testHTTPEndpoint(endpoint string) error {
 	}
 	defer resp.Body.Close()
 	return nil
-}
-
-type Node interface {
-	IP() string
-	Type() NodeClient
-	GetAddr(NodePort) string
 }

--- a/internal/testutil/eth2_lighthouse.go
+++ b/internal/testutil/eth2_lighthouse.go
@@ -23,7 +23,7 @@ func NewLighthouseBeacon(e *Eth1Server) (*LighthouseBeacon, error) {
 		"lighthouse", "beacon_node",
 		"--http", "--http-address", "0.0.0.0",
 		"--http-port", `{{ Port "eth2.http" }}`,
-		"--eth1-endpoints", e.http(),
+		"--eth1-endpoints", e.GetAddr(NodePortEth1Http),
 		"--testnet-dir", "/data",
 		"--http-allow-sync-stalled",
 	}
@@ -52,7 +52,7 @@ func (b *LighthouseBeacon) Type() NodeClient {
 }
 
 type LighthouseValidator struct {
-	node *node
+	*node
 }
 
 func NewLighthouseValidator(account *Account, spec *Eth2Spec, beacon Node) (*LighthouseValidator, error) {

--- a/internal/testutil/eth2_lighthouse.go
+++ b/internal/testutil/eth2_lighthouse.go
@@ -12,7 +12,7 @@ type LighthouseBeacon struct {
 }
 
 // NewLighthouseBeacon creates a new prysm server
-func NewLighthouseBeacon(config *BeaconConfig) (*LighthouseBeacon, error) {
+func NewLighthouseBeacon(config *BeaconConfig) (Node, error) {
 	cmd := []string{
 		"lighthouse", "beacon_node",
 		"--http", "--http-address", "0.0.0.0",
@@ -23,6 +23,7 @@ func NewLighthouseBeacon(config *BeaconConfig) (*LighthouseBeacon, error) {
 	}
 	opts := []nodeOption{
 		WithName("lighthouse-beacon"),
+		WithNodeType(Lighthouse),
 		WithContainer("sigp/lighthouse", "v2.2.1"),
 		WithCmd(cmd),
 		WithMount("/data"),
@@ -44,7 +45,7 @@ type LighthouseValidator struct {
 	*node
 }
 
-func NewLighthouseValidator(config *ValidatorConfig) (*LighthouseValidator, error) {
+func NewLighthouseValidator(config *ValidatorConfig) (Node, error) {
 	cmd := []string{
 		"lighthouse", "vc",
 		"--debug-level", "debug",
@@ -55,6 +56,7 @@ func NewLighthouseValidator(config *ValidatorConfig) (*LighthouseValidator, erro
 	}
 	opts := []nodeOption{
 		WithName("lighthouse-validator"),
+		WithNodeType(Lighthouse),
 		WithContainer("sigp/lighthouse", "v2.2.1"),
 		WithCmd(cmd),
 		WithMount("/data"),

--- a/internal/testutil/eth2_lighthouse_test.go
+++ b/internal/testutil/eth2_lighthouse_test.go
@@ -22,10 +22,19 @@ func TestEth2_Lighthouse_SingleNode(t *testing.T) {
 	err = eth1.MakeDeposit(account, spec.GetChainConfig())
 	assert.NoError(t, err)
 
-	b, err := NewLighthouseBeacon(eth1)
+	bCfg := &BeaconConfig{
+		Spec: spec,
+		Eth1: eth1.node,
+	}
+	b, err := NewLighthouseBeacon(bCfg)
 	assert.NoError(t, err)
 
-	NewLighthouseValidator(account, spec, b)
+	vCfg := &ValidatorConfig{
+		Accounts: []*Account{account},
+		Spec:     spec,
+		Beacon:   b.node,
+	}
+	NewLighthouseValidator(vCfg)
 
 	api := beacon.NewHttpAPI(b.GetAddr(NodePortHttp))
 

--- a/internal/testutil/eth2_lighthouse_test.go
+++ b/internal/testutil/eth2_lighthouse_test.go
@@ -2,53 +2,8 @@ package testutil
 
 import (
 	"testing"
-	"time"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/umbracle/eth2-validator/internal/beacon"
 )
 
 func TestEth2_Lighthouse_SingleNode(t *testing.T) {
-	eth1, err := NewEth1Server()
-	assert.NoError(t, err)
-
-	account := NewAccount()
-
-	spec := &Eth2Spec{
-		DepositContract: eth1.deposit.String(),
-	}
-
-	err = eth1.MakeDeposit(account, spec.GetChainConfig())
-	assert.NoError(t, err)
-
-	bCfg := &BeaconConfig{
-		Spec: spec,
-		Eth1: eth1.node,
-	}
-	b, err := NewLighthouseBeacon(bCfg)
-	assert.NoError(t, err)
-
-	vCfg := &ValidatorConfig{
-		Accounts: []*Account{account},
-		Spec:     spec,
-		Beacon:   b.node,
-	}
-	NewLighthouseValidator(vCfg)
-
-	api := beacon.NewHttpAPI(b.GetAddr(NodePortHttp))
-
-	require.Eventually(t, func() bool {
-		syncing, err := api.Syncing()
-		if err != nil {
-			return false
-		}
-		if syncing.IsSyncing {
-			return false
-		}
-		if syncing.HeadSlot < 2 {
-			return false
-		}
-		return true
-	}, 2*time.Minute, 10*time.Second)
+	testSingleNode(t, NewLighthouseBeacon, NewLighthouseValidator)
 }

--- a/internal/testutil/eth2_prysm.go
+++ b/internal/testutil/eth2_prysm.go
@@ -24,7 +24,7 @@ func NewPrysmBeacon(e *Eth1Server) (*PrysmBeacon, error) {
 	cmd := []string{
 		"--verbosity", "debug",
 		// eth1x
-		"--http-web3provider", e.http(),
+		"--http-web3provider", e.GetAddr(NodePortEth1Http),
 		"--deposit-contract", e.deposit.String(),
 		"--contract-deployment-block", "0",
 		"--chain-id", "1337",
@@ -73,7 +73,7 @@ func (b *PrysmBeacon) Type() NodeClient {
 }
 
 type PrysmValidator struct {
-	node *node
+	*node
 }
 
 const defWalletPassword = "qwerty"

--- a/internal/testutil/eth2_prysm.go
+++ b/internal/testutil/eth2_prysm.go
@@ -14,7 +14,7 @@ type PrysmBeacon struct {
 }
 
 // NewPrysmBeacon creates a new prysm server
-func NewPrysmBeacon(config *BeaconConfig) (*PrysmBeacon, error) {
+func NewPrysmBeacon(config *BeaconConfig) (Node, error) {
 	cmd := []string{
 		"--verbosity", "debug",
 		// eth1x
@@ -45,6 +45,7 @@ func NewPrysmBeacon(config *BeaconConfig) (*PrysmBeacon, error) {
 	}
 	opts := []nodeOption{
 		WithName("prysm-beacon"),
+		WithNodeType(Prysm),
 		WithContainer("gcr.io/prysmaticlabs/prysm/beacon-chain", "v2.0.6"),
 		WithCmd(cmd),
 		WithMount("/data"),
@@ -67,7 +68,7 @@ type PrysmValidator struct {
 
 const defWalletPassword = "qwerty"
 
-func NewPrysmValidator(config *ValidatorConfig /*, account *Account, spec *Eth2Spec, beacon Node*/) (*PrysmValidator, error) {
+func NewPrysmValidator(config *ValidatorConfig) (Node, error) {
 	store := &accountStore{}
 	for _, acct := range config.Accounts {
 		store.AddKey(acct.Bls)
@@ -90,6 +91,7 @@ func NewPrysmValidator(config *ValidatorConfig /*, account *Account, spec *Eth2S
 	}
 	opts := []nodeOption{
 		WithName("prysm-validator"),
+		WithNodeType(Prysm),
 		WithContainer("gcr.io/prysmaticlabs/prysm/validator", "v2.1.0"),
 		WithCmd(cmd),
 		WithMount("/data"),

--- a/internal/testutil/eth2_prysm_test.go
+++ b/internal/testutil/eth2_prysm_test.go
@@ -2,53 +2,8 @@ package testutil
 
 import (
 	"testing"
-	"time"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/umbracle/eth2-validator/internal/beacon"
 )
 
 func TestEth2_Prysm_SingleNode(t *testing.T) {
-	eth1, err := NewEth1Server()
-	assert.NoError(t, err)
-
-	account := NewAccount()
-
-	spec := &Eth2Spec{
-		DepositContract: eth1.deposit.String(),
-	}
-
-	err = eth1.MakeDeposit(account, spec.GetChainConfig())
-	assert.NoError(t, err)
-
-	bCfg := &BeaconConfig{
-		Spec: spec,
-		Eth1: eth1.node,
-	}
-	b, err := NewPrysmBeacon(bCfg)
-	assert.NoError(t, err)
-
-	vCfg := &ValidatorConfig{
-		Accounts: []*Account{account},
-		Spec:     spec,
-		Beacon:   b.node,
-	}
-	NewPrysmValidator(vCfg)
-
-	api := beacon.NewHttpAPI(b.GetAddr(NodePortHttp))
-
-	require.Eventually(t, func() bool {
-		syncing, err := api.Syncing()
-		if err != nil {
-			return false
-		}
-		if syncing.IsSyncing {
-			return false
-		}
-		if syncing.HeadSlot < 2 {
-			return false
-		}
-		return true
-	}, 2*time.Minute, 10*time.Second)
+	testSingleNode(t, NewPrysmBeacon, NewPrysmValidator)
 }

--- a/internal/testutil/eth2_prysm_test.go
+++ b/internal/testutil/eth2_prysm_test.go
@@ -22,10 +22,19 @@ func TestEth2_Prysm_SingleNode(t *testing.T) {
 	err = eth1.MakeDeposit(account, spec.GetChainConfig())
 	assert.NoError(t, err)
 
-	b, err := NewPrysmBeacon(eth1)
+	bCfg := &BeaconConfig{
+		Spec: spec,
+		Eth1: eth1.node,
+	}
+	b, err := NewPrysmBeacon(bCfg)
 	assert.NoError(t, err)
 
-	NewPrysmValidator(account, spec, b)
+	vCfg := &ValidatorConfig{
+		Accounts: []*Account{account},
+		Spec:     spec,
+		Beacon:   b.node,
+	}
+	NewPrysmValidator(vCfg)
 
 	api := beacon.NewHttpAPI(b.GetAddr(NodePortHttp))
 

--- a/internal/testutil/eth2_teku.go
+++ b/internal/testutil/eth2_teku.go
@@ -12,7 +12,7 @@ type TekuBeacon struct {
 }
 
 // NewTekuBeacon creates a new teku server
-func NewTekuBeacon(config *BeaconConfig) (*TekuBeacon, error) {
+func NewTekuBeacon(config *BeaconConfig) (Node, error) {
 	cmd := []string{
 		// eth1x
 		"--eth1-endpoint", config.Eth1.GetAddr(NodePortEth1Http),
@@ -31,6 +31,7 @@ func NewTekuBeacon(config *BeaconConfig) (*TekuBeacon, error) {
 	}
 	opts := []nodeOption{
 		WithName("teku-beacon"),
+		WithNodeType(Teku),
 		WithContainer("consensys/teku", "22.4.0"),
 		WithCmd(cmd),
 		WithMount("/data"),
@@ -51,7 +52,7 @@ type TekuValidator struct {
 	*node
 }
 
-func NewTekuValidator(config *ValidatorConfig) (*TekuValidator, error) {
+func NewTekuValidator(config *ValidatorConfig) (Node, error) {
 	cmd := []string{
 		"vc",
 		// beacon api
@@ -67,6 +68,7 @@ func NewTekuValidator(config *ValidatorConfig) (*TekuValidator, error) {
 	}
 	opts := []nodeOption{
 		WithName("teku-validator"),
+		WithNodeType(Teku),
 		WithContainer("consensys/teku", "22.4.0"),
 		WithCmd(cmd),
 		WithMount("/data"),

--- a/internal/testutil/eth2_teku.go
+++ b/internal/testutil/eth2_teku.go
@@ -19,7 +19,7 @@ func NewTekuBeacon(e *Eth1Server) (*TekuBeacon, error) {
 
 	cmd := []string{
 		// eth1x
-		"--eth1-endpoint", e.http(),
+		"--eth1-endpoint", e.GetAddr(NodePortEth1Http),
 		// eth1x deposit contract
 		"--eth1-deposit-contract-address", e.deposit.String(),
 		// run only beacon node
@@ -61,7 +61,7 @@ func (b *TekuBeacon) Type() NodeClient {
 }
 
 type TekuValidator struct {
-	node *node
+	*node
 }
 
 func NewTekuValidator(account *Account, spec *Eth2Spec, beacon Node) (*TekuValidator, error) {

--- a/internal/testutil/eth2_teku_test.go
+++ b/internal/testutil/eth2_teku_test.go
@@ -9,8 +9,6 @@ import (
 )
 
 func TestEth2_Teku_SingleNode(t *testing.T) {
-	t.Skip()
-
 	eth1, err := NewEth1Server()
 	assert.NoError(t, err)
 
@@ -23,10 +21,19 @@ func TestEth2_Teku_SingleNode(t *testing.T) {
 	err = eth1.MakeDeposit(account, spec.GetChainConfig())
 	assert.NoError(t, err)
 
-	b, err := NewTekuBeacon(eth1)
+	bCfg := &BeaconConfig{
+		Spec: spec,
+		Eth1: eth1.node,
+	}
+	b, err := NewTekuBeacon(bCfg)
 	assert.NoError(t, err)
 
-	NewTekuValidator(account, spec, b)
+	vCfg := &ValidatorConfig{
+		Accounts: []*Account{account},
+		Spec:     spec,
+		Beacon:   b.node,
+	}
+	NewTekuValidator(vCfg)
 
 	api := beacon.NewHttpAPI(b.GetAddr(NodePortHttp))
 

--- a/internal/testutil/eth2_teku_test.go
+++ b/internal/testutil/eth2_teku_test.go
@@ -2,52 +2,8 @@ package testutil
 
 import (
 	"testing"
-	"time"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/umbracle/eth2-validator/internal/beacon"
 )
 
 func TestEth2_Teku_SingleNode(t *testing.T) {
-	eth1, err := NewEth1Server()
-	assert.NoError(t, err)
-
-	account := NewAccount()
-
-	spec := &Eth2Spec{
-		DepositContract: eth1.deposit.String(),
-	}
-
-	err = eth1.MakeDeposit(account, spec.GetChainConfig())
-	assert.NoError(t, err)
-
-	bCfg := &BeaconConfig{
-		Spec: spec,
-		Eth1: eth1.node,
-	}
-	b, err := NewTekuBeacon(bCfg)
-	assert.NoError(t, err)
-
-	vCfg := &ValidatorConfig{
-		Accounts: []*Account{account},
-		Spec:     spec,
-		Beacon:   b.node,
-	}
-	NewTekuValidator(vCfg)
-
-	api := beacon.NewHttpAPI(b.GetAddr(NodePortHttp))
-
-	assert.Eventually(t, func() bool {
-		syncing, err := api.Syncing()
-		if err != nil {
-			return false
-		}
-		if syncing.IsSyncing {
-			return false
-		}
-		if syncing.HeadSlot < 2 {
-			return false
-		}
-		return true
-	}, 2*time.Minute, 10*time.Second)
+	testSingleNode(t, NewTekuBeacon, NewTekuValidator)
 }

--- a/internal/testutil/eth2_teku_test.go
+++ b/internal/testutil/eth2_teku_test.go
@@ -5,5 +5,7 @@ import (
 )
 
 func TestEth2_Teku_SingleNode(t *testing.T) {
+	t.Skip()
+
 	testSingleNode(t, NewTekuBeacon, NewTekuValidator)
 }

--- a/internal/testutil/framework.go
+++ b/internal/testutil/framework.go
@@ -2,7 +2,11 @@ package testutil
 
 import (
 	"fmt"
+	"testing"
+	"time"
 
+	"github.com/stretchr/testify/require"
+	"github.com/umbracle/eth2-validator/internal/beacon"
 	"github.com/umbracle/eth2-validator/internal/bls"
 	"github.com/umbracle/ethgo/wallet"
 )
@@ -23,6 +27,14 @@ type Account struct {
 	Ecdsa *wallet.Key
 }
 
+func NewAccounts(num int) []*Account {
+	accts := []*Account{}
+	for i := 0; i < num; i++ {
+		accts = append(accts, NewAccount())
+	}
+	return accts
+}
+
 func NewAccount() *Account {
 	key, err := wallet.GenerateKey()
 	if err != nil {
@@ -33,4 +45,54 @@ func NewAccount() *Account {
 		Ecdsa: key,
 	}
 	return account
+}
+
+// CreateBeacon is a factory method to create beacon nodes
+type CreateBeacon func(cfg *BeaconConfig) (Node, error)
+
+// CreateValidator is a factory method to create validator nodes
+type CreateValidator func(cfg *ValidatorConfig) (Node, error)
+
+func testSingleNode(t *testing.T, beaconFn CreateBeacon, validatorFn CreateValidator) {
+	eth1, err := NewEth1Server()
+	require.NoError(t, err)
+
+	spec := &Eth2Spec{
+		DepositContract: eth1.deposit.String(),
+	}
+
+	accounts := NewAccounts(1)
+
+	err = eth1.MakeDeposits(accounts, spec.GetChainConfig())
+	require.NoError(t, err)
+
+	bCfg := &BeaconConfig{
+		Spec: spec,
+		Eth1: eth1.node,
+	}
+	b, err := beaconFn(bCfg)
+	require.NoError(t, err)
+
+	vCfg := &ValidatorConfig{
+		Accounts: accounts,
+		Spec:     spec,
+		Beacon:   b,
+	}
+	validatorFn(vCfg)
+
+	api := beacon.NewHttpAPI(b.GetAddr(NodePortHttp))
+
+	require.Eventually(t, func() bool {
+		syncing, err := api.Syncing()
+		if err != nil {
+			return false
+		}
+		if syncing.IsSyncing {
+			return false
+		}
+		if syncing.HeadSlot < 2 {
+			return false
+		}
+		return true
+	}, 2*time.Minute, 10*time.Second)
 }

--- a/internal/testutil/framework.go
+++ b/internal/testutil/framework.go
@@ -1,0 +1,36 @@
+package testutil
+
+import (
+	"fmt"
+
+	"github.com/umbracle/eth2-validator/internal/bls"
+	"github.com/umbracle/ethgo/wallet"
+)
+
+type ValidatorConfig struct {
+	Spec     *Eth2Spec
+	Accounts []*Account
+	Beacon   Node
+}
+
+type BeaconConfig struct {
+	Spec *Eth2Spec
+	Eth1 Node
+}
+
+type Account struct {
+	Bls   *bls.Key
+	Ecdsa *wallet.Key
+}
+
+func NewAccount() *Account {
+	key, err := wallet.GenerateKey()
+	if err != nil {
+		panic(fmt.Errorf("BUG: failed to generate key %v", err))
+	}
+	account := &Account{
+		Bls:   bls.NewRandomKey(),
+		Ecdsa: key,
+	}
+	return account
+}

--- a/internal/testutil/node.go
+++ b/internal/testutil/node.go
@@ -56,7 +56,7 @@ type node struct {
 
 type nodeOption func(*nodeOpts)
 
-func WithNodeClient(nodeClient NodeClient) nodeOption {
+func WithNodeType(nodeClient NodeClient) nodeOption {
 	return func(n *nodeOpts) {
 		n.NodeClient = nodeClient
 	}

--- a/internal/testutil/node.go
+++ b/internal/testutil/node.go
@@ -23,6 +23,14 @@ import (
 	"github.com/hashicorp/go-hclog"
 )
 
+type NodeClient string
+
+const (
+	Teku       NodeClient = "teku"
+	Prysm      NodeClient = "prysm"
+	Lighthouse NodeClient = "lighthouse"
+)
+
 type nodeOpts struct {
 	Repository string
 	Tag        string
@@ -35,6 +43,7 @@ type nodeOpts struct {
 	Logger     hclog.Logger
 	Output     []io.Writer
 	Labels     map[string]string
+	NodeClient NodeClient
 }
 
 type node struct {
@@ -46,6 +55,12 @@ type node struct {
 }
 
 type nodeOption func(*nodeOpts)
+
+func WithNodeClient(nodeClient NodeClient) nodeOption {
+	return func(n *nodeOpts) {
+		n.NodeClient = nodeClient
+	}
+}
 
 func WithHostNetwork() nodeOption {
 	return func(n *nodeOpts) {
@@ -379,6 +394,10 @@ func (n *node) IP() string {
 	return n.ip
 }
 
+func (n *node) Type() NodeClient {
+	return n.opts.NodeClient
+}
+
 func retryFn(handler func() error) error {
 	timeoutT := time.NewTimer(1 * time.Minute)
 
@@ -393,4 +412,9 @@ func retryFn(handler func() error) error {
 			return fmt.Errorf("timeout")
 		}
 	}
+}
+
+type Node interface {
+	GetAddr(NodePort) string
+	Type() NodeClient
 }

--- a/internal/testutil/node.go
+++ b/internal/testutil/node.go
@@ -46,12 +46,18 @@ type nodeOpts struct {
 	NodeClient NodeClient
 }
 
+type exitResult struct {
+	err error
+}
+
 type node struct {
-	cli   *client.Client
-	id    string
-	opts  *nodeOpts
-	ip    string
-	ports map[NodePort]uint64
+	cli        *client.Client
+	id         string
+	opts       *nodeOpts
+	ip         string
+	ports      map[NodePort]uint64
+	waitCh     chan struct{}
+	exitResult *exitResult
 }
 
 type nodeOption func(*nodeOpts)
@@ -217,10 +223,11 @@ func newNode(opts ...nodeOption) (*node, error) {
 	}
 
 	n := &node{
-		cli:   cli,
-		opts:  nOpts,
-		ip:    "127.0.0.1",
-		ports: map[NodePort]uint64{},
+		cli:    cli,
+		opts:   nOpts,
+		ip:     "127.0.0.1",
+		ports:  map[NodePort]uint64{},
+		waitCh: make(chan struct{}),
 	}
 
 	// build CLI arguments which might include template arguments
@@ -260,6 +267,8 @@ func newNode(opts ...nodeOption) (*node, error) {
 		return nil, fmt.Errorf("could not start container: %v", err)
 	}
 
+	go n.run()
+
 	// get the ip of the node if not running as a host network
 	if !nOpts.InHost {
 		containerData, err := cli.ContainerInspect(ctx, n.id)
@@ -279,7 +288,7 @@ func newNode(opts ...nodeOption) (*node, error) {
 	}
 
 	if nOpts.Retry != nil {
-		if err := retryFn(func() error {
+		if err := n.retryFn(func() error {
 			return nOpts.Retry(n)
 		}); err != nil {
 			return nil, err
@@ -344,6 +353,29 @@ func (n *node) execCmd(cmd string) (string, error) {
 	return buf.String(), nil
 }
 
+func (n *node) WaitCh() <-chan struct{} {
+	return n.waitCh
+}
+
+func (n *node) run() {
+	resCh, errCh := n.cli.ContainerWait(context.Background(), n.id, container.WaitConditionNotRunning)
+
+	var exitErr error
+	select {
+	case res := <-resCh:
+		if res.Error != nil {
+			exitErr = fmt.Errorf(res.Error.Message)
+		}
+	case err := <-errCh:
+		exitErr = err
+	}
+
+	n.exitResult = &exitResult{
+		err: exitErr,
+	}
+	close(n.waitCh)
+}
+
 func (n *node) GetAddr(port NodePort) string {
 	num, ok := n.ports[port]
 	if !ok {
@@ -398,7 +430,7 @@ func (n *node) Type() NodeClient {
 	return n.opts.NodeClient
 }
 
-func retryFn(handler func() error) error {
+func (n *node) retryFn(handler func() error) error {
 	timeoutT := time.NewTimer(1 * time.Minute)
 
 	for {
@@ -407,6 +439,9 @@ func retryFn(handler func() error) error {
 			if err := handler(); err == nil {
 				return nil
 			}
+
+		case <-n.waitCh:
+			return fmt.Errorf("node stopped")
 
 		case <-timeoutT.C:
 			return fmt.Errorf("timeout")
@@ -417,4 +452,6 @@ func retryFn(handler func() error) error {
 type Node interface {
 	GetAddr(NodePort) string
 	Type() NodeClient
+	IP() string
+	Stop()
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -7,10 +7,10 @@ var (
 	GitCommit string
 
 	// Version is the main version at the moment.
-	Version = "0.1.0"
+	Version = "0.1.1"
 
 	// VersionPrerelease is a marker for the version.
-	VersionPrerelease = ""
+	VersionPrerelease = "dev"
 )
 
 // GetVersion returns a string representation of the version


### PR DESCRIPTION
This PR improves the e2e framework in two parts:
- It uses dynamically generated ports instead of fixed addresses in order to run the nodes outside docker.
- It lets validators register more than one account.
- It uses configuration files to initialize beacon and validator objects