### PR TITLE
Add fix for blst on CI

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,5 +1,7 @@
 name: Unit tests
 on: [push, pull_request]
+env:
+  CGO_CFLAGS: "-O -D__BLST_PORTABLE__"
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #45. Note that it will be necessary to extend this env variable also for release building.